### PR TITLE
Added thrift meta generation for SAI-Challenger

### DIFF
--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -11,7 +11,7 @@ run-saithrift-client-tests: run-saithrift-ptftests run-saithrift-pytests
 run-saithrift-client-dev-tests: run-saithrift-dev-ptftests run-saithrift-dev-pytests
 
 .PHONY:clean
-clean: kill-all p4-clean sai-clean test-clean network-clean saithrift-server-clean
+clean: kill-all p4-clean sai-clean test-clean network-clean saithrift-server-clean saichallenger-meta-clean
 	rm -rf $(P4_OUTDIR)
 
 kill-all: kill-saithrift-server kill-switch undeploy-ixiac kill-saichallenger-client
@@ -698,21 +698,21 @@ kill-saichallenger-client:
 
 run-saichallenger-tests: run-saichallenger-functional-tests run-saichallenger-scale-tests
 
-run-saichallenger-functional-tests: deploy-ixiac
+run-saichallenger-functional-tests: deploy-ixiac saichallenger-meta
 	$(DOCKER_RUN_SAI_CHALLENGER_CLIENT) \
 	-w /sai-challenger/dash_tests/functional \
 	$(DOCKER_FLAGS) \
 	$(DOCKER_SAI_CHALLENGER_CLIENT_IMG) \
 	./run-tests.sh --setup=$(SAI_CHALLENGER_SETUP_FILE) $(SAI_CHALLENGER_TEST)
 
-run-saichallenger-scale-tests: deploy-ixiac
+run-saichallenger-scale-tests: deploy-ixiac saichallenger-meta
 	$(DOCKER_RUN_SAI_CHALLENGER_CLIENT) \
 	-w /sai-challenger/dash_tests/scale \
 	$(DOCKER_FLAGS) \
 	$(DOCKER_SAI_CHALLENGER_CLIENT_IMG) \
 	./run-tests.sh --setup=$(SAI_CHALLENGER_SETUP_FILE) $(SAI_CHALLENGER_TEST)
 
-run-saichallenger-tutorials: deploy-ixiac
+run-saichallenger-tutorials: deploy-ixiac saichallenger-meta
 	$(DOCKER_RUN_SAI_CHALLENGER_CLIENT) \
 	-w /sai-challenger/dash_tests/functional \
 	$(DOCKER_FLAGS) \
@@ -724,6 +724,8 @@ saichallenger-meta:
 		bash -c "../../../test/SAI-Challenger/scripts/generate_thrift_meta.sh sai_challenger_thrift_metadata.py"
 	mv -f SAI/saithrift/sai_challenger_thrift_metadata.py ../test/SAI-Challenger/common/sai_client/sai_thrift_client/sai_thrift_metadata.py
 
+saichallenger-meta-clean:
+	pushd $(SAI_CHALLENGER_PATH) && git checkout -- common/sai_client/sai_thrift_client/sai_thrift_metadata.py && popd
 ###############################
 # ENVIRONMENT SETUP TARGETS
 ###############################

--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -205,6 +205,7 @@ sai-clean: SAI/SAI libsai-clean saithrift-server-clean
 	rm -rf SAI/SAI/inc SAI/SAI/experimental SAI/SAI/meta
 	cd SAI/SAI && git checkout -- inc experimental meta
 
+
 # Run to recreate same environment as building saithrift client & server
 run-saithrift-bldr-bash:
 	$(DOCKER_RUN_SAITHRIFT_BLDR) \

--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -4,7 +4,7 @@ mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 mkfile_dir := $(dir $(mkfile_path))
 
 # "All" type targets for convenience
-all:p4 sai saithrift-server docker-saithrift-client saichallenger-meta docker-saichallenger-client test
+all:p4 sai saithrift-server docker-saithrift-client docker-saichallenger-client test
 
 run-all-tests:run-libsai-test run-saithrift-client-tests run-saichallenger-tests
 run-saithrift-client-tests: run-saithrift-ptftests run-saithrift-pytests
@@ -204,11 +204,6 @@ sai-clean: SAI/SAI libsai-clean saithrift-server-clean
 	@echo "Restoring SAI subdirectories to baseline..."
 	rm -rf SAI/SAI/inc SAI/SAI/experimental SAI/SAI/meta
 	cd SAI/SAI && git checkout -- inc experimental meta
-
-saichallenger-meta:
-	$(DOCKER_RUN_SAITHRIFT_BLDR) \
-		bash -c "../../../test/SAI-Challenger/scripts/generate_thrift_meta.sh sai_challenger_thrift_metadata.py"
-	mv SAI/saithrift/sai_challenger_thrift_metadata.py ../test/SAI-Challenger/common/sai_client/sai_thrift_client/sai_thrift_metadata.py
 
 # Run to recreate same environment as building saithrift client & server
 run-saithrift-bldr-bash:
@@ -646,7 +641,7 @@ endif
 DOCKER_SAI_CHALLENGER_CLIENT_BLDR_IMG_TAG = $(shell cat dockerfiles/Dockerfile.saichallenger-client-bldr | sha1sum | awk '{print substr($$1,0,11);}')
 DOCKER_SAI_CHALLENGER_CLIENT_BLDR_IMG = $(DOCKER_SAI_CHALLENGER_CLIENT_BLDR_IMG_NAME):$(DOCKER_SAI_CHALLENGER_CLIENT_BLDR_IMG_TAG)
 
-docker-saichallenger-client-bldr:
+docker-saichallenger-client-bldr: saichallenger-meta
 	{ [ x$(ENABLE_DOCKER_PULL) == xy ] && docker pull $(DOCKER_SAI_CHALLENGER_CLIENT_BLDR_IMG); } || \
 		{ pushd $(SAI_CHALLENGER_PATH) && git submodule update --init && ./build.sh -i client && popd; \
 		docker build \
@@ -683,18 +678,19 @@ DOCKER_RUN_SAI_CHALLENGER_CLIENT=docker run \
 	--network=host \
 	--name $(CONTAINER_SAI_CHALLENGER_CLIENT_NAME)
 
-run-saichallenger-client: deploy-ixiac
+run-saichallenger-client: deploy-ixiac saichallenger-meta
 	$(DOCKER_RUN_SAI_CHALLENGER_CLIENT) \
 	-d \
 	--name $(CONTAINER_SAI_CHALLENGER_CLIENT_NAME) \
-	$(DOCKER_SAI_CHALLENGER_CLIENT_IMG)
+	$(DOCKER_SAI_CHALLENGER_CLIENT_IMG) \
+	bash -c "pip3 install /sai-challenger/common /sai-challenger"
 
-run-saichallenger-client-bash: deploy-ixiac
+run-saichallenger-client-bash: deploy-ixiac saichallenger-meta
 	$(DOCKER_RUN_SAI_CHALLENGER_CLIENT) \
 	-w /sai-challenger/dash_tests \
 	$(DOCKER_FLAGS) \
 	$(DOCKER_SAI_CHALLENGER_CLIENT_IMG) \
-	/bin/bash
+	bash -c "pip3 install /sai-challenger/common /sai-challenger && /bin/bash"
 
 kill-saichallenger-client:
 	-docker kill $(CONTAINER_SAI_CHALLENGER_CLIENT_NAME)
@@ -721,6 +717,11 @@ run-saichallenger-tutorials: deploy-ixiac
 	$(DOCKER_FLAGS) \
 	$(DOCKER_SAI_CHALLENGER_CLIENT_IMG) \
 	./run-tests.sh --setup=$(SAI_CHALLENGER_SETUP_FILE) tutorial
+
+saichallenger-meta:
+	$(DOCKER_RUN_SAITHRIFT_BLDR) \
+		bash -c "../../../test/SAI-Challenger/scripts/generate_thrift_meta.sh sai_challenger_thrift_metadata.py"
+	mv -f SAI/saithrift/sai_challenger_thrift_metadata.py ../test/SAI-Challenger/common/sai_client/sai_thrift_client/sai_thrift_metadata.py
 
 ###############################
 # ENVIRONMENT SETUP TARGETS

--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -4,7 +4,7 @@ mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 mkfile_dir := $(dir $(mkfile_path))
 
 # "All" type targets for convenience
-all:p4 sai saithrift-server docker-saithrift-client docker-saichallenger-client test
+all:p4 sai saithrift-server docker-saithrift-client saichallenger-meta docker-saichallenger-client test
 
 run-all-tests:run-libsai-test run-saithrift-client-tests run-saichallenger-tests
 run-saithrift-client-tests: run-saithrift-ptftests run-saithrift-pytests
@@ -205,6 +205,10 @@ sai-clean: SAI/SAI libsai-clean saithrift-server-clean
 	rm -rf SAI/SAI/inc SAI/SAI/experimental SAI/SAI/meta
 	cd SAI/SAI && git checkout -- inc experimental meta
 
+saichallenger-meta:
+	$(DOCKER_RUN_SAITHRIFT_BLDR) \
+		bash -c "../../../test/SAI-Challenger/scripts/generate_thrift_meta.sh sai_challenger_thrift_metadata.py"
+	mv SAI/saithrift/sai_challenger_thrift_metadata.py ../test/SAI-Challenger/common/sai_client/sai_thrift_client/sai_thrift_metadata.py
 
 # Run to recreate same environment as building saithrift client & server
 run-saithrift-bldr-bash:


### PR DESCRIPTION
After changes to SAI thrift we need manually generate   [sai_thrift_metadata.py](https://github.com/opencomputeproject/SAI-Challenger/blob/44458c9d0f8147cf696204ad700bf46f8738180f/common/sai_client/sai_thrift_client/sai_thrift_metadata.py) .

Also we can have 2 different sai_thift_metadata.py files:
1. After cloning git repo and updating SAI-Challenger submodule we have sai_thift_metadata.py for this submodule commit  
2. In  SAI-Challenger client docker image that could be made by CI after some changes:
https://github.com/sonic-net/DASH/blob/1274a460f13a6665e0901b032b3d216b27132944/.github/workflows/dash-saichallenger-client-bldr-docker.yml#L56

In addition, if we working on some changes in SAI would be much better to have an automatically generated [sai_thrift_metadata.py](https://github.com/opencomputeproject/SAI-Challenger/blob/44458c9d0f8147cf696204ad700bf46f8738180f/common/sai_client/sai_thrift_client/sai_thrift_metadata.py)  
file in both the SAI-Challenger  submodule and in the SAI-Challenger client docker.